### PR TITLE
Fix for crash when tariff code cant be found & consumption key is not found in tariff

### DIFF
--- a/app/octopus_api_client.py
+++ b/app/octopus_api_client.py
@@ -92,7 +92,7 @@ class OctopusApiClient:
         product = self._retrieve_product(product_code)
         pricing = {}
         links = self._find_links(product, tariff_code)
-        if links is not None:
+        if links:
             for link in links:
                 pricing[link['rel']] = self._retrieve_paginated_data(link['href'], from_date, to_date)
         return pricing

--- a/app/octopus_api_client.py
+++ b/app/octopus_api_client.py
@@ -91,8 +91,10 @@ class OctopusApiClient:
         product_code, _ = self._extract_product_code(tariff_code)
         product = self._retrieve_product(product_code)
         pricing = {}
-        for link in self._find_links(product, tariff_code):
-            pricing[link['rel']] = self._retrieve_paginated_data(link['href'], from_date, to_date)
+        links = self._find_links(product, tariff_code)
+        if links is not None:
+            for link in links:
+                pricing[link['rel']] = self._retrieve_paginated_data(link['href'], from_date, to_date)
         return pricing
 
     def retrieve_electricity_consumption(self, mpan: str, serial_number: str, from_date: str, to_date: str):


### PR DESCRIPTION
The first edge case only occurs if you are on a tariff that cannot be found.

the tariff we were on previously was E-FLAT2R-VAR-22-11-01-H which is never found by `_find_links` resulting in this crash

```
Traceback (most recent call last):
  File "C:\Users\Michael\Documents\GitHub\octograph\app\octopus_to_influxdb.py", line 298, in <module>
    cmd()
  File "C:\Users\Michael\AppData\Local\Programs\Python\Python312\Lib\site-packages\click\core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Michael\AppData\Local\Programs\Python\Python312\Lib\site-packages\click\core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "C:\Users\Michael\AppData\Local\Programs\Python\Python312\Lib\site-packages\click\core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Michael\AppData\Local\Programs\Python\Python312\Lib\site-packages\click\core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Michael\Documents\GitHub\octograph\app\octopus_to_influxdb.py", line 294, in cmd
    app.collect(from_date, to_date)
  File "C:\Users\Michael\Documents\GitHub\octograph\app\octopus_to_influxdb.py", line 100, in collect
    self._process_property(p, collect_from, collect_to, tags)
  File "C:\Users\Michael\Documents\GitHub\octograph\app\octopus_to_influxdb.py", line 111, in _process_property
    self._process_emp(emp, collect_from, collect_to, tags)
  File "C:\Users\Michael\Documents\GitHub\octograph\app\octopus_to_influxdb.py", line 129, in _process_emp
    pricing_dict = self._get_pricing(emp['agreements'], collect_from, collect_to)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Michael\Documents\GitHub\octograph\app\octopus_to_influxdb.py", line 240, in _get_pricing
    agreement_rates = self._octopus_api.retrieve_tariff_pricing(a['tariff_code'], DateUtils.iso8601(f), DateUtils.iso8601(t))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Michael\Documents\GitHub\octograph\app\octopus_api_client.py", line 95, in retrieve_tariff_pricing
    for link in self._find_links(product, tariff_code):
TypeError: 'NoneType' object is not iterable
```

In this case, I believe we should just skip over the iteration when this occurs. ideally, there would be a way to get the correct tariff data but i dont see any way to do that.

The second edge case occurs when you have consumption data from before the start of the current tariff. the time won't be part of either `standard_unit_rates` or `standing_charges` so both should be checked before accessing.

I wasn't sure if it would be preferred to do this as an `if key in dict` or `try: except keyerror:` within this PR I've done it as the former, but happy to change to the latter if preferred.

```
Traceback (most recent call last):
  File "C:\Users\Michael\Documents\GitHub\octograph\app\octopus_to_influxdb.py", line 300, in <module>
    cmd()
  File "C:\Users\Michael\AppData\Local\Programs\Python\Python312\Lib\site-packages\click\core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Michael\AppData\Local\Programs\Python\Python312\Lib\site-packages\click\core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "C:\Users\Michael\AppData\Local\Programs\Python\Python312\Lib\site-packages\click\core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Michael\AppData\Local\Programs\Python\Python312\Lib\site-packages\click\core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Michael\Documents\GitHub\octograph\app\octopus_to_influxdb.py", line 296, in cmd
    app.collect(from_date, to_date)
  File "C:\Users\Michael\Documents\GitHub\octograph\app\octopus_to_influxdb.py", line 100, in collect
    self._process_property(p, collect_from, collect_to, tags)
  File "C:\Users\Michael\Documents\GitHub\octograph\app\octopus_to_influxdb.py", line 111, in _process_property
    self._process_emp(emp, collect_from, collect_to, tags)
  File "C:\Users\Michael\Documents\GitHub\octograph\app\octopus_to_influxdb.py", line 151, in _process_emp
    self._process_em(emp['mpan'], em, collect_from, collect_to, standard_unit_rates, standing_charges, tags)
  File "C:\Users\Michael\Documents\GitHub\octograph\app\octopus_to_influxdb.py", line 161, in _process_em
    self._store_em_consumption(consumption, standard_unit_rates, standing_charges, tags)
  File "C:\Users\Michael\Documents\GitHub\octograph\app\octopus_to_influxdb.py", line 164, in _store_em_consumption
    self._store_consumption('electricity_consumption', consumption, standard_unit_rates, standing_charges, base_tags)
  File "C:\Users\Michael\Documents\GitHub\octograph\app\octopus_to_influxdb.py", line 175, in _store_consumption
    usage_cost_exc_vat_pence = standard_unit_rates[time]['value_exc_vat'] * c['consumption']
                               ~~~~~~~~~~~~~~~~~~~^^^^^^
KeyError: '2024-04-15T22:30:00Z'
```

