### PR TITLE
Add export meter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,6 @@ If you have not built the image locally, change the image and tag to one from [D
 
 ## Known Issues
 
-* Import meters have not been tested and are not supported.
 * The cubic meter to kWh conversion used fixed values whereas they actually fluctuate (see link below).
 
 ## Links


### PR DESCRIPTION
With this change, "usage" and "cost" for export meters & tariffs are stored as negative values, which makes the default Grafana dashboard show correct "net" figures (e.g. 10 kWh import @ 10p/kWh and 5 kWh export @ 5p/kWh is shown as 5 kWh "total electricity used" and 75p "total cost" (assuming no standing charge in this example).