### PR TITLE
Fix issue with queries searching for tags that don't exist

### DIFF
--- a/app/octopus_to_influxdb.py
+++ b/app/octopus_to_influxdb.py
@@ -103,7 +103,7 @@ class OctopusToInflux:
         tags = base_tags.copy()
         click.echo(f'Processing property: {p["address_line_1"]}, {p["postcode"]}')
         for field in ['address_line_1', 'address_line_2', 'address_line_3', 'town', 'postcode']:
-            if f'property_{field}' in self._included_tags:
+            if f'property_{field}' in self._included_tags and p[field] != '':
                 tags[f'property_{field}'] = p[field]
         if len(p['electricity_meter_points']) == 0:
             click.echo('No electricity meter points found in property')


### PR DESCRIPTION
This fixes an issue I was having where one of the tags listed in my "included_tags" list was actually empty (not set on the Octopus API side). For whatever reason, the tag doesn't get written to Influx, but because the tag is in my "included_tags" list, queries to the database include checking for entries matching the tag. This results in empty query results.

This change ensures we discard any tags whose values are empty strings in the _process_property function (and all subsequent ones).

This change fixes the issue for me but maybe there is a nicer way of doing this?