### PR TITLE
Fixed lookup against old properties

### DIFF
--- a/app/octopus_api_client.py
+++ b/app/octopus_api_client.py
@@ -82,7 +82,12 @@ class OctopusApiClient:
         return results
 
     def retrieve_account(self, account_number: str):
-        return self._retrieve_data(f'accounts/{account_number}/')
+        account_data = self._retrieve_data(f'accounts/{account_number}/')
+        account_data['properties'] = [
+            property for property in account_data.get("properties", [])
+            if property.get("moved_out_at") is None
+        ]
+        return account_data
 
     def _retrieve_product(self, code: str):
         return self._retrieve_data(f'products/{code}/')

--- a/app/octopus_api_client.py
+++ b/app/octopus_api_client.py
@@ -82,12 +82,7 @@ class OctopusApiClient:
         return results
 
     def retrieve_account(self, account_number: str):
-        account_data = self._retrieve_data(f'accounts/{account_number}/')
-        account_data['properties'] = [
-            property for property in account_data.get("properties", [])
-            if property.get("moved_out_at") is None
-        ]
-        return account_data
+        return self._retrieve_data(f'accounts/{account_number}/')
 
     def _retrieve_product(self, code: str):
         return self._retrieve_data(f'products/{code}/')

--- a/app/octopus_to_influxdb.py
+++ b/app/octopus_to_influxdb.py
@@ -136,7 +136,10 @@ class OctopusToInflux:
             self._process_intelligent_slots(self._intelligent_tariff_meter, tags)
 
         for p in account['properties']:
-            self._process_property(p, collect_from, collect_to, tags)
+            if 'moved_out_at' in p and p['moved_out_at']:
+                click.echo(f"Skipping property at {p['address_line_1']}, {p['postcode']} due to move-out date being set.")
+            else:
+                self._process_property(p, collect_from, collect_to, tags)
 
     def _process_property(self, p, collect_from: datetime, collect_to: datetime, base_tags: dict[str, str]):
         tags = base_tags.copy()


### PR DESCRIPTION
Added a filter to remove returned properties where the "moved_out_at" field was populated as trying to retrieve data against these meters caused the program to crash.