### PR TITLE
Update octopus_to_influxdb.py - fix for missing standing charge data

### DIFF
--- a/app/octopus_to_influxdb.py
+++ b/app/octopus_to_influxdb.py
@@ -310,7 +310,7 @@ class OctopusToInflux:
                     for r in [x for x in results if not x['payment_method'] or x['payment_method'] == self._payment_method]:
                         pricing_rows.append({
                             'tariff_code': a['tariff_code'],
-                            'valid_from': DateUtils.iso8601(max(f, datetime.fromisoformat(r['valid_from']))),
+                            'valid_from': DateUtils.iso8601(f if not r['valid_from'] else max(f, datetime.fromisoformat(r['valid_from']))),
                             'valid_to': DateUtils.iso8601(t if not r['valid_to'] else min(t, datetime.fromisoformat(r['valid_to']))),
                             'value_exc_vat': r['value_exc_vat'],
                             'value_inc_vat': r['value_inc_vat'],


### PR DESCRIPTION
Fixes issue with missing standing charge data (when both valid_from and valid_to are None), same issue as highlighted by @yurividal in PR #7 

This is an issue I noticed when trying to import data for an export meter - the standing charge data for my tariff (E-11R-AGILE-OUTGOING-19-05-13-B) is as follows:
```
{
    "count": 1,
    "next": null,
    "previous": null,
    "results": [
        {
            "value_exc_vat": 0.0,
            "value_inc_vat": 0.0,
            "valid_from": null,
            "valid_to": null,
            "payment_method": null
        }
    ]
}
```